### PR TITLE
Add detailed field to __buildSalesTaxContext

### DIFF
--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -160,6 +160,17 @@ SalesTax.prototype.getAmountWithSalesTax = function(
   // Acquire sales tax, then process amount.
   return self.getSalesTax(countryCode, stateCode, taxNumber)
     .then(function(tax) {
+
+      var detailed = Object.keys(tax.detailed).map(function(type) {
+        var rate = tax.detailed[type];
+
+        return {
+          type: type,
+          rate: rate,
+          amount: rate * amount
+        };
+      });
+
       return __Promise.resolve({
         type     : tax.type,
         rate     : tax.rate,
@@ -167,7 +178,8 @@ SalesTax.prototype.getAmountWithSalesTax = function(
         total    : (1.00 + tax.rate) * amount,
         area     : tax.area,
         exchange : tax.exchange,
-        charge   : tax.charge
+        charge   : tax.charge,
+        detailed : detailed
       });
     });
 };
@@ -448,11 +460,23 @@ SalesTax.prototype.__buildSalesTaxContext = function(
   // Generate tax type (multiple sales tax may apply, eg. country + state)
   var type = countryTax.type;
 
+  // also keep the tax rate separated for country with state taxes that requires
+  // the invoice to be filled separately
+  var detailed = {};
+
   if (stateTax.rate > 0) {
     if (countryTax.rate > 0) {
+
+      // add both tax rate
+      detailed[type] = countryTax.rate;
+      detailed[stateTax.type] = stateTax.rate;
+
       type = type + "+" + stateTax.type;
     } else {
       type = stateTax.type;
+
+      // only add state rate
+      detailed[type] = stateTax.rate;
     }
   }
 
@@ -471,6 +495,7 @@ SalesTax.prototype.__buildSalesTaxContext = function(
   return {
     type     : type,
     rate     : (isExempt === true) ? 0.00 : fullRate,
+    detailed  : (isExempt === true) ? {} : detailed,
     area     : taxArea,
     exchange : taxExchange,
     charge   : taxCharge


### PR DESCRIPTION
This is so we can generate Canadian invoices with this library. In Canada, you need to list individual amounts of taxes on the invoice because they are filed to different government bodies.

It passes jshint, and no tests are broken (this is purely additive). 

Hope we can get this merged. 

Merci! 