### PR TITLE
Correct New Zealand (NZ) tax type to "GST"

### DIFF
--- a/res/sales_tax_rates.json
+++ b/res/sales_tax_rates.json
@@ -441,7 +441,7 @@
   },
 
   "NZ": {
-    "type": "vat",
+    "type": "gst",
     "rate": 0.15
   },
 


### PR DESCRIPTION
The sales tax used in New Zealand is called "GST", not "VAT".  For confirmation, please see: https://www.ird.govt.nz/gst