### PR TITLE
Update sales_tax_rates.json for Estonia

### DIFF
--- a/res/sales_tax_rates.json
+++ b/res/sales_tax_rates.json
@@ -297,7 +297,14 @@
   "EE": {
     "type": "vat",
     "currency": "EUR",
-    "rate": 0.2
+    "rate": 0.22
+    "before": {
+      "2023-12-31T22:00:00.000Z": {
+        "type": "vat",
+        "currency": "EUR",
+        "rate": 0.2
+      }
+    }
   },
 
   "EG": {


### PR DESCRIPTION
Estonia changing vat from 0.2 to 0.22 taking effect the 1st of January 2024