### PR TITLE
Fix Greece VAT number online check

### DIFF
--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -276,6 +276,11 @@ SalesTax.prototype.validateTaxNumber = function(
             // Split VAT number (n extract actual VAT number)
             var splitMatch = cleanTaxNumber.match(regex_eu_vat);
 
+            if (countryCode === 'GR') {
+              // Greece has 'EL' code in EU VAT
+              countryCode = 'EL';
+            }
+
             // Check fraud on EU VAT number?
             if (splitMatch && splitMatch[1]) {
               check_fraud_eu_vat(


### PR DESCRIPTION
Greece uses 'EL', not 'GR' for VAT numbers. 'EL' must be passed to `validate-vat` for VAT number online check.

`validate-vat` supported countries list: https://github.com/viruschidai/validate-vat/blob/master/src/index.coffee#L24 and related commit: https://github.com/viruschidai/validate-vat/commit/b07a1b9dbae5590c39d284f7182cac6066e843db