### PR TITLE
update JP and TR rates

### DIFF
--- a/res/sales_tax_rates.json
+++ b/res/sales_tax_rates.json
@@ -479,7 +479,7 @@
   "JP": {
     "type": "vat",
     "currency": "JPY",
-    "rate": 0.08
+    "rate": 0.1
   },
 
   "KE": {
@@ -861,7 +861,7 @@
   "TR": {
     "type": "vat",
     "currency": "TRY",
-    "rate": 0.18
+    "rate": 0.2
   },
 
   "TT": {


### PR DESCRIPTION
Japan's rate was changed to 10% in October 2019.
Turkey's rate was changed to 20% on the 10th of July 2023.