### PR TITLE
use jsvat-next & support Northern Ireland

### DIFF
--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -11,12 +11,12 @@
 
 var fetch = require("node-fetch").default;
 var check_fraud_eu_vat = require("validate-vat");
-var validate_eu_vat = require("jsvat");
+var validate_eu_and_gb_vat = require("jsvat-next");
 var validate_us_vat = require("ein-validator");
 
 var regex_whitespace = /\s/g;
 var regex_eu_vat = /^([A-Z]{2})(.+)$/;
-var regex_gb_vat = /^GB([0-9]{9}([0-9]{3})?|[A-Z]{2}[0-9]{3})$/;
+var regex_gb_vat = /^(GB|XI)(.+)$/;
 var regex_ca_vat = /^[0-9]{9}$/;
 
 var validate_gb_vat_url = (
@@ -229,15 +229,29 @@ SalesTax.prototype.validateTaxNumber = function(
 
       // United Kingdom
       if (countryCode === "GB") {
-        // Validate GB VAT number
-        var splitMatch = cleanTaxNumber.match(regex_gb_vat);
-        var isValid = ((splitMatch && splitMatch[1]) ? true : false);
+        // Validate GB VAT number (offline check)
+        var validationInfo = validate_eu_and_gb_vat.checkVAT(
+            cleanTaxNumber, validate_eu_and_gb_vat.countries
+        );
+
+        // Check if VAT number is valid
+        var isValid = (validationInfo.isValid && true);
+
+        // No country match?
+        if (isValid === true &&
+            ((validationInfo.country || {}).isoCode || {}).short !==
+            countryCode) {
+          isValid = false;
+        }
 
         // Check number for fraud? (online check)
         if (isValid === true && self.enabledTaxNumberFraudCheck === true) {
+          // Split VAT number (n extract actual VAT number)
+          var splitMatch = cleanTaxNumber.match(regex_gb_vat);
+
           // Query UK HMRC validation API
           return fetch(
-            validate_gb_vat_url + "/" + splitMatch[1]
+            validate_gb_vat_url + "/" + splitMatch[2]
           )
             .then(function(response) {
               return Promise.resolve(
@@ -257,8 +271,8 @@ SalesTax.prototype.validateTaxNumber = function(
       if ((region_countries.EU || []).indexOf(countryCode) !== -1) {
         return new Promise(function(resolve, reject) {
           // Validate EU VAT number (offline check)
-          var validationInfo = validate_eu_vat.checkVAT(
-            cleanTaxNumber, validate_eu_vat.countries
+          var validationInfo = validate_eu_and_gb_vat.checkVAT(
+            cleanTaxNumber, validate_eu_and_gb_vat.countries
           );
 
           // Check if VAT number is valid

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "node-fetch": "2.6.12",
     "validate-vat": "0.9.0",
-    "jsvat": "2.5.3",
+    "jsvat-next": "3.0.2",
     "ein-validator": "1.0.1"
   },
   "devDependencies": {

--- a/test/sales_tax-test.js
+++ b/test/sales_tax-test.js
@@ -175,7 +175,7 @@ describe("node-sales-tax", function() {
           assert.equal(
             tax.type, "vat", "Tax type should be VAT"
           );
-          
+
           assert.equal(
             tax.rate, 0.20, "Tax rate should be 20%"
           );
@@ -527,7 +527,7 @@ describe("node-sales-tax", function() {
           assert.equal(
             tax.type, "vat", "Tax type should be VAT"
           );
-          
+
           assert.equal(
             tax.rate, 0.00, "Tax rate should be 0%"
           );
@@ -1841,6 +1841,15 @@ describe("node-sales-tax", function() {
             isValid, "Tax number should be valid"
           );
         });
+    });
+
+    it("🇬🇧 should check United Kingdom - Northern Ireland tax number as valid", function() {
+      return SalesTax.validateTaxNumber("GB", "XI252257178")
+          .then(function(isValid) {
+              assert.ok(
+                  isValid, "Tax number should be valid"
+              );
+          });
     });
 
     it("🇬🇧 should check United Kingdom tax number as invalid", function() {


### PR DESCRIPTION
Used `jsvat` package is not actively supported anymore. But it has a maintained fork with multiple updates, including GB/XI support (linked issue: https://github.com/valeriansaliou/node-sales-tax/issues/51): https://www.npmjs.com/package/jsvat-next.

- Swapped `jsvat` with `jsvat-next`.
- Changed to use `jsvat-next` also for GB VAT number format validation.
- Added test for Northern Ireland VAT number verification (real VAT number, can be also used for online testing).