### PR TITLE
feat: remove node-fetch from lib

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,7 +8,6 @@
     "escape",
     "Buffer",
     "console",
-    "module",
-    "fetch"
+    "module"
   ]
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -8,6 +8,7 @@
     "escape",
     "Buffer",
     "console",
-    "module"
+    "module",
+    "fetch"
   ]
 }

--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -12,6 +12,7 @@
 var check_fraud_eu_vat = require("validate-vat");
 var validate_eu_vat = require("jsvat");
 var validate_us_vat = require("ein-validator");
+var fetch = require('cross-fetch');
 
 var regex_whitespace = /\s/g;
 var regex_eu_vat = /^([A-Z]{2})(.+)$/;

--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -9,7 +9,6 @@
 "use strict";
 
 
-var fetch = require("node-fetch").default;
 var check_fraud_eu_vat = require("validate-vat");
 var validate_eu_vat = require("jsvat");
 var validate_us_vat = require("ein-validator");

--- a/package.json
+++ b/package.json
@@ -25,13 +25,12 @@
   "main": "lib/sales_tax.js",
   "types": "types/sales_tax.d.ts",
   "engines": {
-    "node": ">= 6.4.0"
+    "node": ">= 18"
   },
   "scripts": {
     "test": "check-build && tsc && istanbul cover _mocha"
   },
   "dependencies": {
-    "node-fetch": "2.6.12",
     "validate-vat": "0.9.0",
     "jsvat": "2.5.3",
     "ein-validator": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
   "main": "lib/sales_tax.js",
   "types": "types/sales_tax.d.ts",
   "engines": {
-    "node": ">= 18"
+    "node": ">= 14"
   },
   "scripts": {
     "test": "check-build && tsc && istanbul cover _mocha"
   },
   "dependencies": {
+    "cross-fetch": "4.0.0",
     "validate-vat": "0.9.0",
     "jsvat": "2.5.3",
     "ein-validator": "1.0.1"


### PR DESCRIPTION
I'd like to use this lib on an edge environment (Vercel) and node-fetch has incompatible dependencies 

The goal of this pr is to use node / edge built-in fetch 