### PR TITLE
chore: update finland tax rate

### DIFF
--- a/res/sales_tax_rates.json
+++ b/res/sales_tax_rates.json
@@ -351,7 +351,15 @@
   "FI": {
     "type": "vat",
     "currency": "EUR",
-    "rate": 0.24
+    "rate": 0.255,
+
+    "before": {
+      "2024-08-31T22:00:00.000Z": {
+        "type": "vat",
+        "currency": "EUR",
+        "rate": 0.24
+      }
+    }
   },
 
   "FR": {


### PR DESCRIPTION
The tax rate for Finland was changed to 25.5% in September 2024