### PR TITLE
Intoduces tax type IGIC and fixes the broken unit test

### DIFF
--- a/res/sales_tax_rates.json
+++ b/res/sales_tax_rates.json
@@ -333,7 +333,7 @@
 
       "GC": {
         "rate": -0.07,
-        "type": "vat"
+        "type": "igic"
       },
 
       "ML": {
@@ -343,7 +343,7 @@
 
       "TF": {
         "rate": -0.07,
-        "type": "vat"
+        "type": "igic"
       }
     }
   },

--- a/test/sales_tax-test.js
+++ b/test/sales_tax-test.js
@@ -1699,11 +1699,11 @@ describe("node-sales-tax", function() {
         return SalesTax.getAmountWithSalesTax("ES", "GC", 1000.00)
           .then(function(tax) {
             assert.equal(
-              tax.type, "vat", "Tax type should be VAT"
+              tax.type, "igic", "Tax type should be IGIC"
             );
 
             assert.equal(
-              tax.rate, 0.00, "Tax rate should be 0%"
+              tax.rate, 0.07, "Tax rate should be 7%"
             );
 
             assert.equal(
@@ -1731,7 +1731,7 @@ describe("node-sales-tax", function() {
             );
 
             assert.equal(
-              tax.total, 1000.00, "Total amount should be 1000.00"
+              tax.total, 1070.00, "Total amount should be 1070.00"
             );
 
             assert.equal(


### PR DESCRIPTION
@valeriansaliou The PR fixes the unit test broken by the prev PR and introduces IGIC as tax type.

I'd like to update SalesTax.prototype.validateTaxNumber to handle the IGIC exception, but I should change the function signature introducing a breaking change (we should pass both country and state/province or an Alpha-2 code like "ES-GC"). 
Any hint?