### PR TITLE
feat: Ghana Tax ID Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,23 @@ United States EIN (U.S. Employer Identification Number) are validated against EI
 
 Canada BN (Business Number) are validated against BN format rules.
 
+### :ghana: Ghana
+
+Ghana tax identification numbers are validated against two formats:
+
+1. TIN (Tax Identification Number)
+   - Must start with either 'C' or 'P'
+   - Followed by exactly 10 digits
+   - Example: C0123456789
+
+2. Ghana Card
+   - Format: GHA-XXXXXXXXX-Y
+   - Where X represents 9 digits
+   - Y is a check digit
+   - Example: GHA-123456789-1
+
+Both formats are validated for proper structure and the Ghana Card includes check digit validation.
+
 ### :black_flag: Rest of the world
 
 If a country or economic community is not listed here, provided tax identification numbers are ignored for those countries (considered as invalid — so do not rely on validation methods as a source of truth).

--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -262,23 +262,9 @@ SalesTax.prototype.validateTaxNumber = function (
           return Promise.resolve(true);
         }
 
-        // Check if it's a Ghana Card (normalize format by removing hyphens)
-        var normalizedGhanaCard = cleanTaxNumber.replace(/-/g, "");
-        if (regex_gh_card.test(normalizedGhanaCard)) {
-          var digits = normalizedGhanaCard.replace("GHA", "").split("");
-          var checkDigit = parseInt(digits.pop());
-
-          // Simple Luhn algorithm for check digit validation
-          var sum = digits.reverse().reduce((acc, curr, idx) => {
-            let num = parseInt(curr);
-            if (idx % 2 === 0) {
-              num *= 2;
-              if (num > 9) num -= 9;
-            }
-            return acc + num;
-          }, 0);
-
-          return Promise.resolve((10 - (sum % 10)) % 10 === checkDigit);
+        // Check if it's a Ghana Card
+        if (regex_gh_card.test(cleanTaxNumber)) {
+          return Promise.resolve(true);
         }
 
         return Promise.resolve(false);

--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -18,6 +18,8 @@ var regex_whitespace = /\s/g;
 var regex_eu_vat = /^([A-Z]{2})(.+)$/;
 var regex_gb_vat = /^GB([0-9]{9}([0-9]{3})?|[A-Z]{2}[0-9]{3})$/;
 var regex_ca_vat = /^[0-9]{9}$/;
+var regex_gh_tin = /^[CP][0-9]{10}$/;
+var regex_gh_card = /^GHA-[0-9]{9}-[0-9]$/;
 
 var validate_gb_vat_url = (
   "https://api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup"
@@ -27,9 +29,9 @@ var tax_rates = require("../res/sales_tax_rates.json");
 var region_countries = require("../res/region_countries.json");
 
 var tax_default_object = {
-  type     : "none",
-  rate     : 0.00,
-  currency : null
+  type: "none",
+  rate: 0.00,
+  currency: null
 };
 
 
@@ -38,7 +40,7 @@ var tax_default_object = {
  * @class
  * @classdesc  Instanciates a new sales tax object
  */
-var SalesTax = function() {
+var SalesTax = function () {
   this.taxOriginCountry = null;
   this.useRegionalTax = true;
   this.enabledTaxNumberValidation = true;
@@ -52,7 +54,7 @@ var SalesTax = function() {
  * @param  {string}  countryCode
  * @return {boolean} Whether country has sales tax
  */
-SalesTax.prototype.hasSalesTax = function(
+SalesTax.prototype.hasSalesTax = function (
   countryCode
 ) {
   countryCode = (countryCode || "").toUpperCase();
@@ -71,7 +73,7 @@ SalesTax.prototype.hasSalesTax = function(
  * @param  {string}  stateCode
  * @return {boolean} Whether country state has sales tax
  */
-SalesTax.prototype.hasStateSalesTax = function(
+SalesTax.prototype.hasStateSalesTax = function (
   countryCode, stateCode
 ) {
   countryCode = (countryCode || "").toUpperCase();
@@ -95,7 +97,7 @@ SalesTax.prototype.hasStateSalesTax = function(
  * @param  {string} [taxNumber]
  * @return {object} Promise object (returns the sales tax from 0 to 1)
  */
-SalesTax.prototype.getSalesTax = function(
+SalesTax.prototype.getSalesTax = function (
   countryCode, stateCode, taxNumber
 ) {
   var self = this;
@@ -113,7 +115,7 @@ SalesTax.prototype.getSalesTax = function(
   var countryTax, stateTax;
 
   if (targetArea === "regional" && this.useRegionalTax === false &&
-        this.taxOriginCountry !== null) {
+    this.taxOriginCountry !== null) {
     countryTax = (
       this.__readCurrentTaxRates(this.taxOriginCountry) || tax_default_object
     );
@@ -129,7 +131,7 @@ SalesTax.prototype.getSalesTax = function(
 
   if (countryTax.rate > 0 || stateTax.rate > 0) {
     return self.getTaxExchangeStatus(countryCode, stateCode, taxNumber)
-      .then(function(exchangeStatus) {
+      .then(function (exchangeStatus) {
         return Promise.resolve(
           self.__buildSalesTaxContext(countryTax, stateTax, exchangeStatus)
         );
@@ -151,7 +153,7 @@ SalesTax.prototype.getSalesTax = function(
  * @param  {string} [taxNumber]
  * @return {object} Promise object (returns the total tax amount)
  */
-SalesTax.prototype.getAmountWithSalesTax = function(
+SalesTax.prototype.getAmountWithSalesTax = function (
   countryCode, stateCode, amount, taxNumber
 ) {
   var self = this;
@@ -163,30 +165,30 @@ SalesTax.prototype.getAmountWithSalesTax = function(
 
   // Acquire sales tax, then process amount.
   return self.getSalesTax(countryCode, stateCode, taxNumber)
-    .then(function(tax) {
+    .then(function (tax) {
       // Generate amount details (list of all sub-amounts from each sub-tax \
       //   rate)
       var amountDetails = [];
 
       for (var i = 0; i < tax.details.length; i++) {
         amountDetails.push({
-          type   : tax.details[i].type,
-          rate   : tax.details[i].rate,
-          amount : tax.details[i].rate * amount
+          type: tax.details[i].type,
+          rate: tax.details[i].rate,
+          amount: tax.details[i].rate * amount
         });
       }
 
       // Return total amount with sales tax
       return Promise.resolve({
-        type     : tax.type,
-        rate     : tax.rate,
-        currency : tax.currency,
-        price    : amount,
-        total    : (1.00 + tax.rate) * amount,
-        area     : tax.area,
-        exchange : tax.exchange,
-        charge   : tax.charge,
-        details  : amountDetails
+        type: tax.type,
+        rate: tax.rate,
+        currency: tax.currency,
+        price: amount,
+        total: (1.00 + tax.rate) * amount,
+        area: tax.area,
+        exchange: tax.exchange,
+        charge: tax.charge,
+        details: amountDetails
       });
     });
 };
@@ -199,7 +201,7 @@ SalesTax.prototype.getAmountWithSalesTax = function(
  * @param  {string} taxNumber
  * @return {object} Promise object (returns a boolean for validity)
  */
-SalesTax.prototype.validateTaxNumber = function(
+SalesTax.prototype.validateTaxNumber = function (
   countryCode, taxNumber
 ) {
   var self = this;
@@ -239,13 +241,13 @@ SalesTax.prototype.validateTaxNumber = function(
           return fetch(
             validate_gb_vat_url + "/" + splitMatch[1]
           )
-            .then(function(response) {
+            .then(function (response) {
               return Promise.resolve(
                 (response.status >= 200 && response.status <= 299) ?
                   true : false
               );
             })
-            .catch(function(error) {
+            .catch(function (error) {
               return Promise.reject(error);
             });
         }
@@ -253,9 +255,38 @@ SalesTax.prototype.validateTaxNumber = function(
         return Promise.resolve(isValid);
       }
 
+      // Ghana
+      if (countryCode === 'GH') {
+        // Check if its a TIN
+        if (regex_gh_tin.test(cleanTaxNumber)) {
+          return Promise.resolve(true);
+        }
+
+        // Check if it's a Ghana Card (normalize format by removing hyphens)
+        var normalizedGhanaCard = cleanTaxNumber.replace(/-/g, "");
+        if (regex_gh_card.test(normalizedGhanaCard)) {
+          var digits = normalizedGhanaCard.replace("GHA", "").split("");
+          var checkDigit = parseInt(digits.pop());
+
+          // Simple Luhn algorithm for check digit validation
+          var sum = digits.reverse().reduce((acc, curr, idx) => {
+            let num = parseInt(curr);
+            if (idx % 2 === 0) {
+              num *= 2;
+              if (num > 9) num -= 9;
+            }
+            return acc + num;
+          }, 0);
+
+          return Promise.resolve((10 - (sum % 10)) % 10 === checkDigit);
+        }
+
+        return Promise.resolve(false);
+      }
+
       // European Union member states (sourced from dynamic list)
       if ((region_countries.EU || []).indexOf(countryCode) !== -1) {
-        return new Promise(function(resolve, reject) {
+        return new Promise(function (resolve, reject) {
           // Validate EU VAT number (offline check)
           var validationInfo = validate_eu_vat.checkVAT(
             cleanTaxNumber, validate_eu_vat.countries
@@ -266,8 +297,8 @@ SalesTax.prototype.validateTaxNumber = function(
 
           // No country match?
           if (isValid === true &&
-                ((validationInfo.country || {}).isoCode || {}).short !==
-                  countryCode) {
+            ((validationInfo.country || {}).isoCode || {}).short !==
+            countryCode) {
             isValid = false;
           }
 
@@ -286,7 +317,7 @@ SalesTax.prototype.validateTaxNumber = function(
               check_fraud_eu_vat(
                 splitMatch[1], splitMatch[2],
 
-                function(error, fraudInfo) {
+                function (error, fraudInfo) {
                   if (error) {
                     return reject(error);
                   }
@@ -323,7 +354,7 @@ SalesTax.prototype.validateTaxNumber = function(
  * @param  {string} [taxNumber]
  * @return {object} Promise object (returns an exchange status object)
  */
-SalesTax.prototype.getTaxExchangeStatus = function(
+SalesTax.prototype.getTaxExchangeStatus = function (
   countryCode, stateCode, taxNumber
 ) {
   var self = this;
@@ -339,38 +370,38 @@ SalesTax.prototype.getTaxExchangeStatus = function(
     // Check for tax-exempt status? (if tax number is provided)
     if (taxNumber) {
       return self.validateTaxNumber(countryCode, taxNumber)
-        .then(function(isValid) {
+        .then(function (isValid) {
           // Consider valid numbers as tax-exempt (overrides exempt status if \
           //   area is national)
           if (isValid === true) {
             return Promise.resolve({
-              exchange : "business",
-              area     : targetArea,
-              exempt   : (targetArea !== "national" && true)
+              exchange: "business",
+              area: targetArea,
+              exempt: (targetArea !== "national" && true)
             });
           }
 
           return Promise.resolve({
-            exchange : "consumer",
-            area     : targetArea,
-            exempt   : false
+            exchange: "consumer",
+            area: targetArea,
+            exempt: false
           });
         });
     }
 
     // Consider as non tax-exempt
     return Promise.resolve({
-      exchange : "consumer",
-      area     : targetArea,
-      exempt   : false
+      exchange: "consumer",
+      area: targetArea,
+      exempt: false
     });
   }
 
   // Consider as tax-exempt (country has no sales tax)
   return Promise.resolve({
-    exchange : "consumer",
-    area     : targetArea,
-    exempt   : true
+    exchange: "consumer",
+    area: targetArea,
+    exempt: true
   });
 };
 
@@ -381,7 +412,7 @@ SalesTax.prototype.getTaxExchangeStatus = function(
  * @param  {string} countryCode
  * @return {undefined}
  */
-SalesTax.prototype.setTaxOriginCountry = function(
+SalesTax.prototype.setTaxOriginCountry = function (
   countryCode, useRegionalTax
 ) {
   this.taxOriginCountry = ((countryCode || "").toUpperCase() || null);
@@ -398,7 +429,7 @@ SalesTax.prototype.setTaxOriginCountry = function(
  * @param  {boolean} enabled
  * @return {undefined}
  */
-SalesTax.prototype.toggleEnabledTaxNumberValidation = function(
+SalesTax.prototype.toggleEnabledTaxNumberValidation = function (
   enabled
 ) {
   this.enabledTaxNumberValidation = (enabled && true);
@@ -411,7 +442,7 @@ SalesTax.prototype.toggleEnabledTaxNumberValidation = function(
  * @param  {boolean} enabled
  * @return {undefined}
  */
-SalesTax.prototype.toggleEnabledTaxNumberFraudCheck = function(
+SalesTax.prototype.toggleEnabledTaxNumberFraudCheck = function (
   enabled
 ) {
   this.enabledTaxNumberFraudCheck = (enabled && true);
@@ -424,7 +455,7 @@ SalesTax.prototype.toggleEnabledTaxNumberFraudCheck = function(
  * @param  {string} countryCode
  * @return {string} Target area
  */
-SalesTax.prototype.__getTargetArea = function(
+SalesTax.prototype.__getTargetArea = function (
   countryCode
 ) {
   // Default to worldwide
@@ -440,7 +471,7 @@ SalesTax.prototype.__getTargetArea = function(
         var regionCountries = region_countries[region];
 
         if (regionCountries.indexOf(this.taxOriginCountry) !== -1 &&
-              regionCountries.indexOf(countryCode) !== -1) {
+          regionCountries.indexOf(countryCode) !== -1) {
           targetArea = "regional";
 
           break;
@@ -461,7 +492,7 @@ SalesTax.prototype.__getTargetArea = function(
  * @param  {object} [exchangeStatus]
  * @return {object} Sales tax context object
  */
-SalesTax.prototype.__buildSalesTaxContext = function(
+SalesTax.prototype.__buildSalesTaxContext = function (
   countryTax, stateTax, exchangeStatus
 ) {
   // Acquire exchange + exempt + area
@@ -510,27 +541,27 @@ SalesTax.prototype.__buildSalesTaxContext = function(
   if (isExempt !== true) {
     if (countryTax.rate > 0) {
       taxDetails.push({
-        type : countryTax.type,
-        rate : countryTax.rate
+        type: countryTax.type,
+        rate: countryTax.rate
       });
     }
     if (stateTax.rate > 0) {
       taxDetails.push({
-        type : stateTax.type,
-        rate : stateTax.rate
+        type: stateTax.type,
+        rate: stateTax.rate
       });
     }
   }
 
   // Build sales tax context
   return {
-    type     : type,
-    rate     : (isExempt === true) ? 0.00 : fullRate,
-    currency : (countryTax.currency || null),
-    area     : taxArea,
-    exchange : taxExchange,
-    charge   : taxCharge,
-    details  : taxDetails
+    type: type,
+    rate: (isExempt === true) ? 0.00 : fullRate,
+    currency: (countryTax.currency || null),
+    area: taxArea,
+    exchange: taxExchange,
+    charge: taxCharge,
+    details: taxDetails
   };
 };
 
@@ -541,7 +572,7 @@ SalesTax.prototype.__buildSalesTaxContext = function(
  * @param  {object} countryCode
  * @return {object} Current tax rates
  */
-SalesTax.prototype.__readCurrentTaxRates = function(
+SalesTax.prototype.__readCurrentTaxRates = function (
   countryCode
 ) {
   var countryTaxRates = tax_rates[countryCode];
@@ -596,7 +627,7 @@ SalesTax.prototype.__readCurrentTaxRates = function(
  * @param  {string}  stateCode
  * @return {boolean} Whether country and state added result in a tax or not
  */
-SalesTax.prototype.__hasTotalSalesTax = function(
+SalesTax.prototype.__hasTotalSalesTax = function (
   countryCode, stateCode
 ) {
   countryCode = (countryCode || "").toUpperCase();
@@ -622,7 +653,7 @@ SalesTax.prototype.__hasTotalSalesTax = function(
  * @private
  * @return {object} Current date
  */
-SalesTax.prototype.__getCurrentDate = function() {
+SalesTax.prototype.__getCurrentDate = function () {
   // Return current date
   // Notice: this function is useless as-is, though it comes handy when \
   //   unit-testing the library, as it lets us override current date with \

--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -29,9 +29,9 @@ var tax_rates = require("../res/sales_tax_rates.json");
 var region_countries = require("../res/region_countries.json");
 
 var tax_default_object = {
-  type: "none",
-  rate: 0.00,
-  currency: null
+  type     : "none",
+  rate     : 0.00,
+  currency : null
 };
 
 
@@ -40,7 +40,7 @@ var tax_default_object = {
  * @class
  * @classdesc  Instanciates a new sales tax object
  */
-var SalesTax = function () {
+var SalesTax = function() {
   this.taxOriginCountry = null;
   this.useRegionalTax = true;
   this.enabledTaxNumberValidation = true;
@@ -54,7 +54,7 @@ var SalesTax = function () {
  * @param  {string}  countryCode
  * @return {boolean} Whether country has sales tax
  */
-SalesTax.prototype.hasSalesTax = function (
+SalesTax.prototype.hasSalesTax = function(
   countryCode
 ) {
   countryCode = (countryCode || "").toUpperCase();
@@ -73,7 +73,7 @@ SalesTax.prototype.hasSalesTax = function (
  * @param  {string}  stateCode
  * @return {boolean} Whether country state has sales tax
  */
-SalesTax.prototype.hasStateSalesTax = function (
+SalesTax.prototype.hasStateSalesTax = function(
   countryCode, stateCode
 ) {
   countryCode = (countryCode || "").toUpperCase();
@@ -97,7 +97,7 @@ SalesTax.prototype.hasStateSalesTax = function (
  * @param  {string} [taxNumber]
  * @return {object} Promise object (returns the sales tax from 0 to 1)
  */
-SalesTax.prototype.getSalesTax = function (
+SalesTax.prototype.getSalesTax = function(
   countryCode, stateCode, taxNumber
 ) {
   var self = this;
@@ -115,7 +115,7 @@ SalesTax.prototype.getSalesTax = function (
   var countryTax, stateTax;
 
   if (targetArea === "regional" && this.useRegionalTax === false &&
-    this.taxOriginCountry !== null) {
+        this.taxOriginCountry !== null) {
     countryTax = (
       this.__readCurrentTaxRates(this.taxOriginCountry) || tax_default_object
     );
@@ -131,7 +131,7 @@ SalesTax.prototype.getSalesTax = function (
 
   if (countryTax.rate > 0 || stateTax.rate > 0) {
     return self.getTaxExchangeStatus(countryCode, stateCode, taxNumber)
-      .then(function (exchangeStatus) {
+      .then(function(exchangeStatus) {
         return Promise.resolve(
           self.__buildSalesTaxContext(countryTax, stateTax, exchangeStatus)
         );
@@ -153,7 +153,7 @@ SalesTax.prototype.getSalesTax = function (
  * @param  {string} [taxNumber]
  * @return {object} Promise object (returns the total tax amount)
  */
-SalesTax.prototype.getAmountWithSalesTax = function (
+SalesTax.prototype.getAmountWithSalesTax = function(
   countryCode, stateCode, amount, taxNumber
 ) {
   var self = this;
@@ -165,30 +165,30 @@ SalesTax.prototype.getAmountWithSalesTax = function (
 
   // Acquire sales tax, then process amount.
   return self.getSalesTax(countryCode, stateCode, taxNumber)
-    .then(function (tax) {
+    .then(function(tax) {
       // Generate amount details (list of all sub-amounts from each sub-tax \
       //   rate)
       var amountDetails = [];
 
       for (var i = 0; i < tax.details.length; i++) {
         amountDetails.push({
-          type: tax.details[i].type,
-          rate: tax.details[i].rate,
-          amount: tax.details[i].rate * amount
+          type   : tax.details[i].type,
+          rate   : tax.details[i].rate,
+          amount : tax.details[i].rate * amount
         });
       }
 
       // Return total amount with sales tax
       return Promise.resolve({
-        type: tax.type,
-        rate: tax.rate,
-        currency: tax.currency,
-        price: amount,
-        total: (1.00 + tax.rate) * amount,
-        area: tax.area,
-        exchange: tax.exchange,
-        charge: tax.charge,
-        details: amountDetails
+        type     : tax.type,
+        rate     : tax.rate,
+        currency : tax.currency,
+        price    : amount,
+        total    : (1.00 + tax.rate) * amount,
+        area     : tax.area,
+        exchange : tax.exchange,
+        charge   : tax.charge,
+        details  : amountDetails
       });
     });
 };
@@ -201,7 +201,7 @@ SalesTax.prototype.getAmountWithSalesTax = function (
  * @param  {string} taxNumber
  * @return {object} Promise object (returns a boolean for validity)
  */
-SalesTax.prototype.validateTaxNumber = function (
+SalesTax.prototype.validateTaxNumber = function(
   countryCode, taxNumber
 ) {
   var self = this;
@@ -241,13 +241,13 @@ SalesTax.prototype.validateTaxNumber = function (
           return fetch(
             validate_gb_vat_url + "/" + splitMatch[1]
           )
-            .then(function (response) {
+            .then(function(response) {
               return Promise.resolve(
                 (response.status >= 200 && response.status <= 299) ?
                   true : false
               );
             })
-            .catch(function (error) {
+            .catch(function(error) {
               return Promise.reject(error);
             });
         }
@@ -272,7 +272,7 @@ SalesTax.prototype.validateTaxNumber = function (
 
       // European Union member states (sourced from dynamic list)
       if ((region_countries.EU || []).indexOf(countryCode) !== -1) {
-        return new Promise(function (resolve, reject) {
+        return new Promise(function(resolve, reject) {
           // Validate EU VAT number (offline check)
           var validationInfo = validate_eu_vat.checkVAT(
             cleanTaxNumber, validate_eu_vat.countries
@@ -283,8 +283,8 @@ SalesTax.prototype.validateTaxNumber = function (
 
           // No country match?
           if (isValid === true &&
-            ((validationInfo.country || {}).isoCode || {}).short !==
-            countryCode) {
+                ((validationInfo.country || {}).isoCode || {}).short !==
+                  countryCode) {
             isValid = false;
           }
 
@@ -303,7 +303,7 @@ SalesTax.prototype.validateTaxNumber = function (
               check_fraud_eu_vat(
                 splitMatch[1], splitMatch[2],
 
-                function (error, fraudInfo) {
+                function(error, fraudInfo) {
                   if (error) {
                     return reject(error);
                   }
@@ -340,7 +340,7 @@ SalesTax.prototype.validateTaxNumber = function (
  * @param  {string} [taxNumber]
  * @return {object} Promise object (returns an exchange status object)
  */
-SalesTax.prototype.getTaxExchangeStatus = function (
+SalesTax.prototype.getTaxExchangeStatus = function(
   countryCode, stateCode, taxNumber
 ) {
   var self = this;
@@ -356,38 +356,38 @@ SalesTax.prototype.getTaxExchangeStatus = function (
     // Check for tax-exempt status? (if tax number is provided)
     if (taxNumber) {
       return self.validateTaxNumber(countryCode, taxNumber)
-        .then(function (isValid) {
+        .then(function(isValid) {
           // Consider valid numbers as tax-exempt (overrides exempt status if \
           //   area is national)
           if (isValid === true) {
             return Promise.resolve({
-              exchange: "business",
-              area: targetArea,
-              exempt: (targetArea !== "national" && true)
+              exchange : "business",
+              area     : targetArea,
+              exempt   : (targetArea !== "national" && true)
             });
           }
 
           return Promise.resolve({
-            exchange: "consumer",
-            area: targetArea,
-            exempt: false
+            exchange : "consumer",
+            area     : targetArea,
+            exempt   : false
           });
         });
     }
 
     // Consider as non tax-exempt
     return Promise.resolve({
-      exchange: "consumer",
-      area: targetArea,
-      exempt: false
+      exchange : "consumer",
+      area     : targetArea,
+      exempt   : false
     });
   }
 
   // Consider as tax-exempt (country has no sales tax)
   return Promise.resolve({
-    exchange: "consumer",
-    area: targetArea,
-    exempt: true
+    exchange : "consumer",
+    area     : targetArea,
+    exempt   : true
   });
 };
 
@@ -398,7 +398,7 @@ SalesTax.prototype.getTaxExchangeStatus = function (
  * @param  {string} countryCode
  * @return {undefined}
  */
-SalesTax.prototype.setTaxOriginCountry = function (
+SalesTax.prototype.setTaxOriginCountry = function(
   countryCode, useRegionalTax
 ) {
   this.taxOriginCountry = ((countryCode || "").toUpperCase() || null);
@@ -415,7 +415,7 @@ SalesTax.prototype.setTaxOriginCountry = function (
  * @param  {boolean} enabled
  * @return {undefined}
  */
-SalesTax.prototype.toggleEnabledTaxNumberValidation = function (
+SalesTax.prototype.toggleEnabledTaxNumberValidation = function(
   enabled
 ) {
   this.enabledTaxNumberValidation = (enabled && true);
@@ -428,7 +428,7 @@ SalesTax.prototype.toggleEnabledTaxNumberValidation = function (
  * @param  {boolean} enabled
  * @return {undefined}
  */
-SalesTax.prototype.toggleEnabledTaxNumberFraudCheck = function (
+SalesTax.prototype.toggleEnabledTaxNumberFraudCheck = function(
   enabled
 ) {
   this.enabledTaxNumberFraudCheck = (enabled && true);
@@ -441,7 +441,7 @@ SalesTax.prototype.toggleEnabledTaxNumberFraudCheck = function (
  * @param  {string} countryCode
  * @return {string} Target area
  */
-SalesTax.prototype.__getTargetArea = function (
+SalesTax.prototype.__getTargetArea = function(
   countryCode
 ) {
   // Default to worldwide
@@ -457,7 +457,7 @@ SalesTax.prototype.__getTargetArea = function (
         var regionCountries = region_countries[region];
 
         if (regionCountries.indexOf(this.taxOriginCountry) !== -1 &&
-          regionCountries.indexOf(countryCode) !== -1) {
+              regionCountries.indexOf(countryCode) !== -1) {
           targetArea = "regional";
 
           break;
@@ -478,7 +478,7 @@ SalesTax.prototype.__getTargetArea = function (
  * @param  {object} [exchangeStatus]
  * @return {object} Sales tax context object
  */
-SalesTax.prototype.__buildSalesTaxContext = function (
+SalesTax.prototype.__buildSalesTaxContext = function(
   countryTax, stateTax, exchangeStatus
 ) {
   // Acquire exchange + exempt + area
@@ -527,27 +527,27 @@ SalesTax.prototype.__buildSalesTaxContext = function (
   if (isExempt !== true) {
     if (countryTax.rate > 0) {
       taxDetails.push({
-        type: countryTax.type,
-        rate: countryTax.rate
+        type : countryTax.type,
+        rate : countryTax.rate
       });
     }
     if (stateTax.rate > 0) {
       taxDetails.push({
-        type: stateTax.type,
-        rate: stateTax.rate
+        type : stateTax.type,
+        rate : stateTax.rate
       });
     }
   }
 
   // Build sales tax context
   return {
-    type: type,
-    rate: (isExempt === true) ? 0.00 : fullRate,
-    currency: (countryTax.currency || null),
-    area: taxArea,
-    exchange: taxExchange,
-    charge: taxCharge,
-    details: taxDetails
+    type     : type,
+    rate     : (isExempt === true) ? 0.00 : fullRate,
+    currency : (countryTax.currency || null),
+    area     : taxArea,
+    exchange : taxExchange,
+    charge   : taxCharge,
+    details  : taxDetails
   };
 };
 
@@ -558,7 +558,7 @@ SalesTax.prototype.__buildSalesTaxContext = function (
  * @param  {object} countryCode
  * @return {object} Current tax rates
  */
-SalesTax.prototype.__readCurrentTaxRates = function (
+SalesTax.prototype.__readCurrentTaxRates = function(
   countryCode
 ) {
   var countryTaxRates = tax_rates[countryCode];
@@ -613,7 +613,7 @@ SalesTax.prototype.__readCurrentTaxRates = function (
  * @param  {string}  stateCode
  * @return {boolean} Whether country and state added result in a tax or not
  */
-SalesTax.prototype.__hasTotalSalesTax = function (
+SalesTax.prototype.__hasTotalSalesTax = function(
   countryCode, stateCode
 ) {
   countryCode = (countryCode || "").toUpperCase();
@@ -639,7 +639,7 @@ SalesTax.prototype.__hasTotalSalesTax = function (
  * @private
  * @return {object} Current date
  */
-SalesTax.prototype.__getCurrentDate = function () {
+SalesTax.prototype.__getCurrentDate = function() {
   // Return current date
   // Notice: this function is useless as-is, though it comes handy when \
   //   unit-testing the library, as it lets us override current date with \

--- a/test/sales_tax-test.js
+++ b/test/sales_tax-test.js
@@ -1851,6 +1851,34 @@ describe("node-sales-tax", function() {
           );
         });
     });
+
+    it("🇬🇭 should validate correct Ghana TIN", function() {
+      return SalesTax.validateTaxNumber("GH", "C0123456789")
+        .then(function(isValid) {
+          assert.ok(isValid, "Valid Ghana TIN should be accepted");
+        });
+    });
+  
+    it("🇬🇭 should validate correct Ghana Card", function() {
+      return SalesTax.validateTaxNumber("GH", "GHA-002343458-4")
+        .then(function(isValid) {
+          assert.ok(isValid, "Valid Ghana Card should be accepted");
+        });
+    });
+  
+    it("🇬🇭 should reject invalid Ghana TIN", function() {
+      return SalesTax.validateTaxNumber("GH", "X0123456789")
+        .then(function(isValid) {
+          assert.ok(!isValid, "Invalid Ghana TIN should be rejected");
+        });
+    });
+  
+    it("🇬🇭 should reject invalid Ghana Card", function() {
+      return SalesTax.validateTaxNumber("GH", "GHA-12345-1")
+        .then(function(isValid) {
+          assert.ok(!isValid, "Invalid Ghana Card should be rejected");
+        });
+    });
   });
 
   describe("getTaxExchangeStatus", function() {


### PR DESCRIPTION
# Add Ghana Tax ID Validation Support

## Changes
- Added validation for Ghana Tax Identification Numbers (TIN)
  - Format: `C/P` followed by 10 digits (e.g., C0123456789)
- Added validation for Ghana Card numbers
  - Format: `GHA-XXXXXXXXX-Y` where X are digits and Y is a check digit