### PR TITLE
Prevent deprecated punycode usage

### DIFF
--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -9,7 +9,14 @@
 "use strict";
 
 
-var fetch = require('cross-fetch');
+var fetchApi = typeof fetch === 'function' ? fetch : undefined;
+if (typeof global !== 'undefined' && global.fetch) {
+  fetchApi = global.fetch;
+}
+// } else if (typeof window !== 'undefined' && window.fetch) {
+//   fetchApi = window.fetch;
+// }
+var fetch = !fetchApi ? require('cross-fetch') : fetchApi;
 var check_fraud_eu_vat = require("validate-vat");
 var validate_eu_vat = require("jsvat");
 var validate_us_vat = require("ein-validator");


### PR DESCRIPTION
Down the `cross-fetch` dependency the `whatwg-url@5.0.0` module uses the deprecated `punycode` api.

This PR omits to require `cross-fetch` if the native fetch api of Node.js is available (should be the case since v18)

This will prevent the punycode deprecation warning and a workaround like this is not necessary: https://github.com/valeriansaliou/node-sales-tax/pull/67#issuecomment-2356531316

```sh
(node:55558) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```


```sh
└─┬ sales-tax@2.18.0
  └─┬ cross-fetch@4.0.0
    └─┬ node-fetch@2.7.0
      └── whatwg-url@5.0.0
```

more infos: https://github.com/node-fetch/node-fetch/pull/1793#issuecomment-1839050150