### PR TITLE
Use jsvat-next

### DIFF
--- a/lib/sales_tax.js
+++ b/lib/sales_tax.js
@@ -15,7 +15,7 @@ var is_node = (
 
 var check_fraud_eu_vat = is_node ? require("validate-vat") : null;
 
-var validate_eu_vat = require("jsvat");
+var validate_eu_vat = require("jsvat-next");
 var validate_us_vat = require("ein-validator");
 
 var regex_whitespace = /\s/g;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "validate-vat": "0.9.0",
-    "jsvat": "2.5.3",
+    "jsvat-next": "3.0.4",
     "ein-validator": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Jsvat is no longer maintained.

Some countries, such as Belgium, updated their VAT IDs, and it was not updated in jsvat since it's no longer maintained.

jsvat-next has been updated to support necessary changes: https://github.com/mathieumagalhaes/jsvat-next/commit/3c079e6e4e1ffe72158f94b63b62ec4f8e6946a0